### PR TITLE
Added argparse

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,6 +79,27 @@ exec(open("configurator.py").read())  # overrides from command line or config fi
 config = {k: globals()[k] for k in config_keys}  # will be useful for logging
 # -----------------------------------------------------------------------------
 
+# argparse
+import argparse
+# initialize
+parser = argparse.ArgumentParser()
+# specify config file
+parser.add_argument('config_yml', help='path to config YML')
+# runtime overrides are optional
+parser.add_argument('--overrides', '-o', help='CLI runtime overrides',
+        default={})
+# generate config
+args = parser.parse_args()
+config_yml = args.config_yml
+overrides = args.overrides
+# parse with yaml
+import yaml
+with open(config_yml, 'r') as f:
+    config = yaml.safe_load(f)
+# overrides
+for k in overrides:
+    config[k] = overrides[k]
+
 # fixing some hyperparams to sensible defaults
 lr_decay_iters = max_iters  # should be ~= max_iters per Chinchilla
 min_lr = 0.0  # minimum learning rate, should be ~= learning_rate/10 per Chinchilla

--- a/train.py
+++ b/train.py
@@ -70,15 +70,6 @@ device = "cuda"  # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps
 dtype = "bfloat16"  # float32|bfloat16|float16
 compile = True  # use PyTorch 2.0 to compile the model to be faster
 # -----------------------------------------------------------------------------
-config_keys = [
-    k
-    for k, v in globals().items()
-    if not k.startswith("_") and isinstance(v, (int, float, bool, str))
-]
-exec(open("configurator.py").read())  # overrides from command line or config file
-config = {k: globals()[k] for k in config_keys}  # will be useful for logging
-# -----------------------------------------------------------------------------
-
 # argparse
 import argparse
 # initialize
@@ -99,7 +90,7 @@ with open(config_yml, 'r') as f:
 # overrides
 for k in overrides:
     config[k] = overrides[k]
-
+# -----------------------------------------------------------------------------
 # fixing some hyperparams to sensible defaults
 lr_decay_iters = max_iters  # should be ~= max_iters per Chinchilla
 min_lr = 0.0  # minimum learning rate, should be ~= learning_rate/10 per Chinchilla


### PR DESCRIPTION
This is an alternative to the `configurator.py` script using argparse (and PyYAML). `train.py` would read a base/template YAML with defaults, then overrides can be specified in an optional dictionary.

The example from `configurator.py`
```$ python train.py config/override_file.py --batch_size=32```

becomes
```$ python train.py config/config.yml --overrides {'batch_size':32}```
or
```$ python train.py config/config.yml -o {'batch_size':32}```