### PR TITLE
Codon support. 74 times speedup compared to Python

### DIFF
--- a/llama2.py
+++ b/llama2.py
@@ -5,9 +5,18 @@ import time
 import random
 import math
 import struct
+from typing import List
 
 
 class Config:
+    dim: int
+    hidden_dim: int
+    n_layers: int
+    n_heads: int
+    n_kv_heads: int
+    vocab_size: int
+    seq_len: int
+
     def __init__(self, dim, hidden_dim, n_layers, n_heads, n_kv_heads, vocab_size, seq_len):
         self.dim = dim
         self.hidden_dim = hidden_dim
@@ -19,21 +28,20 @@ class Config:
 
 
 class TransformerWeights:
-    token_embedding_table: None
-    freq_cis_real: None
-    freq_cis_imag: None
-    rms_att_weight: None
-    wq: None
-    wk: None
-    wv: None
-    wo: None
-    rms_ffn_weight: None
-    w1: None
-    w3: None
-    w2: None
-    rms_final_weight: None
-    wcls: None
-
+    token_embedding_table: List[float]
+    rms_att_weight: List[float]
+    wq: List[float]
+    wk: List[float]
+    wv: List[float]
+    wo: List[float]
+    rms_ffn_weight: List[float]
+    w1: List[float]
+    w3: List[float]
+    w2: List[float]
+    rms_final_weight: List[float]
+    freq_cis_real: List[float]
+    freq_cis_imag: List[float]
+    wcls: List[float]
 
 # ----------------------------------------------------------------------------
 # initialization: read from checkpoint
@@ -129,18 +137,18 @@ def matmul(xout, x, w, n, d):
 
 
 class RunState:
-    x: None
-    xb: None
-    q: None
-    k: None
-    v: None
-    att: None
-    key_cache: None
-    value_cache: None
-    xb2: None
-    hb: None
-    hb2: None
-    logits: None
+    x: List[float]
+    xb: List[float]
+    q: List[float]
+    k: List[float]
+    v: List[float]
+    att: List[float]
+    key_cache: List[float]
+    value_cache: List[float]
+    xb2: List[float]
+    hb: List[float]
+    hb2: List[float]
+    logits: List[float]
 
 
 # token, pos, config, state, weights
@@ -222,7 +230,7 @@ def transformer(token: int, pos: int, conf: Config, state: RunState, weights: Tr
 
             xb_ptr = h * head_size
             # Weighted sum of the values, store back into xb
-            state.xb[xb_ptr: (h + 1) * head_size] = [0] * head_size
+            state.xb[xb_ptr: (h + 1) * head_size] = [0.0] * head_size
             for t in range(pos + 1):
                 # Get the value vector for this head and at this timestep
                 v = state.value_cache[loff + t * dim + h *
@@ -297,7 +305,7 @@ def bpe_encode(text, vocab, vocab_scores):
         id = str_lookup(string, vocab)
         if id == -1:
             print(f"not a good prompt at pos {pos}")
-            exit(1)
+            sys.exit(1)
         tokens.append(id)
 
     # Merge the best consecutive pair each iteration, according to the scores in vocab_scores
@@ -357,24 +365,24 @@ def argmax(v):
 
 
 def init_run_state(state, config):
-    state.x = [0] * config.dim
-    state.xb = [0] * config.dim
-    state.xb2 = [0] * config.dim
-    state.hb = [0] * config.hidden_dim
-    state.hb2 = [0] * config.hidden_dim
-    state.q = [0] * config.dim
-    state.k = [0] * config.dim
-    state.v = [0] * config.dim
-    state.att = [0] * (config.n_heads * config.seq_len)
-    state.logits = [0] * config.vocab_size
-    state.key_cache = [0] * (config.n_layers * config.seq_len * config.dim)
-    state.value_cache = [0] * (config.n_layers * config.seq_len * config.dim)
+    state.x = [0.0] * config.dim
+    state.xb = [0.0] * config.dim
+    state.xb2 = [0.0] * config.dim
+    state.hb = [0.0] * config.hidden_dim
+    state.hb2 = [0.0] * config.hidden_dim
+    state.q = [0.0] * config.dim
+    state.k = [0.0] * config.dim
+    state.v = [0.0] * config.dim
+    state.att = [0.0] * (config.n_heads * config.seq_len)
+    state.logits = [0.0] * config.vocab_size
+    state.key_cache = [0.0] * (config.n_layers * config.seq_len * config.dim)
+    state.value_cache = [0.0] * (config.n_layers * config.seq_len * config.dim)
 
 
 def run(args):
     checkpoint = args["checkpoint"]
-    temperature = args["temperature"]
-    steps = args["steps"]
+    temperature = float(args["temperature"])
+    steps = int(args["steps"])
     prompt = args["prompt"]
 
     rng_seed = int(time.time())
@@ -477,8 +485,8 @@ def run(args):
 if __name__ == "__main__":
     args = {
         "checkpoint": './out/stories15M.bin',
-        "temperature": 0.0,
-        "steps": 256,
+        "temperature": "0.0",
+        "steps": "256",
         "prompt": None
     }
     # if len(sys.argv) < 2:
@@ -490,10 +498,10 @@ if __name__ == "__main__":
         args["checkpoint"] = sys.argv[1]
 
     if len(sys.argv) >= 3:
-        args["temperature"] = float(sys.argv[2])
+        args["temperature"] = sys.argv[2]
 
     if len(sys.argv) >= 4:
-        args["steps"] = int(sys.argv[3])
+        args["steps"] = sys.argv[3]
 
     if len(sys.argv) >= 5:
         args["prompt"] = sys.argv[4]

--- a/llama2.py
+++ b/llama2.py
@@ -82,8 +82,10 @@ def tokenizer_init(conf: Config, file):
     for i in range(0, conf.vocab_size):
         vocab_scores.append(read_types(1, 'f')[0])
         len = read_types(1)[0]
-        bstr = read_types(1, f'{len}s', len)
-        vocab.append(bstr[0])
+        bstr = file.read(len)
+        if type(bstr) is not str:
+            bstr = bstr.decode('utf8')
+        vocab.append(bstr)
     return vocab, vocab_scores, max_token_length
 
 
@@ -285,9 +287,6 @@ def transformer(token: int, pos: int, conf: Config, state: RunState, weights: Tr
 
 
 def str_lookup(string, vocab):
-    # little trick to make string always compatible with byte-encoded tokens in vocab list
-    string = string.encode() if isinstance(string, str) else string
-
     # Find the first perfect match for string in vocab, return its index or -1 if not found
     try:
         index = vocab.index(string)
@@ -465,7 +464,6 @@ def run(args):
             if token == 1 and vocab[next_token][0] == ' ' else vocab[next_token]
         )
 
-        token_str = token_str.decode("utf-8")
         print(token_str, end="")
         sys.stdout.flush()
 

--- a/struct.codon
+++ b/struct.codon
@@ -1,0 +1,37 @@
+from typing import Union
+
+def unpack(fmt: str, s) -> Union[list[float],list[int]]:
+    n = 1
+    i = 0
+    while i < len(fmt) and fmt[i].isdigit():
+        i += 1
+    if i > 1: n = int(fmt[0:i])
+
+    fmt = fmt[i:]
+
+    i = 0
+    if fmt == 'I':
+        return [ int(Ptr[u32](s[i:i+4].ptr)[0]) for i in range(0, len(s) // 4 * 4, 4) ]
+    if fmt == 'i':
+        return [ int(Ptr[i32](s[i:i+4].ptr)[0]) for i in range(0, len(s) // 4 * 4, 4) ]
+    elif fmt == 'f':
+        return [ float(Ptr[f32](s[i:i+4].ptr)[0]) for i in range(0, len(s) // 4 * 4, 4) ]
+
+def calcsize(fmt: str):
+    n = 1
+    i = 0
+    while i < len(fmt) and fmt[i].isdigit():
+        i += 1
+    if i > 0: n = int(fmt[0:i])
+
+    fmt = fmt[i:]
+
+    return n * 4 if fmt == 'I' or fmt == 'i' or fmt == 'f' else -1
+
+
+if __name__ == "__main__":
+    s='\x01\x00\x00\x00\xb0\xb1\xb2\xb3abcda000'
+    print(unpack('I', s))
+    print(unpack('i', s))
+    print(unpack('f', s))
+


### PR DESCRIPTION
This set of changes adds ability to compile llama2.py with Codon.

The result is a 74 X speedup!

As Codon currently has no 'struct', this required implementing trivial struct functions used here.  But only Codon would see that. The other changes are clean python changes for Codon compatibility.
 
---

% python3 llama2.py stories15M.bin 0 8 ' Linus'
Linus was walking in the park.
achieved tok/s: 0.9232392508572935

% mypyc llama2.py
% python3 -c 'import llama2' stories15M.bin 0 8 ' Linus'
Linus was walking in the park.
achieved tok/s: 0.9944594402614008

(1.1x)

% codon run llama2.py stories15M.bin 0 8 ' Linus'
Linus was walking in the park.
achieved tok/s: 10.4948

(11x)

% codon run --release llama2.py stories15M.bin 0 8 ' Linus'
Linus was walking in the park.
achieved tok/s: 68.6275

(74x)
